### PR TITLE
Create Microchat marketing landing page

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -1,77 +1,25 @@
-import { BrowserRouter } from "react-router-dom";
-import React, { lazy, Suspense, useEffect, useState } from "react";
+import Header from "./components/microchat/Header";
+import Hero from "./components/microchat/Hero";
+import FeatureGrid from "./components/microchat/FeatureGrid";
+import Testimonials from "./components/microchat/Testimonials";
+import Pricing from "./components/microchat/Pricing";
+import Faq from "./components/microchat/Faq";
+import Cta from "./components/microchat/Cta";
+import Footer from "./components/microchat/Footer";
 
-import CanvasLoader from "./components/Loader";
-
-const Navbar = lazy(() => import("./components/Navbar"));
-const Hero = lazy(() => import("./components/Hero"));
-const About = lazy(() => import("./components/About"));
-const Works = lazy(() => import("./components/Works"));
-const Experience = lazy(() => import("./components/Experience"));
-const Feedbacks = lazy(() => import("./components/Feedbacks"));
-const Tech = lazy(() => import("./components/Tech"));
-const Contact = lazy(() => import("./components/Contact"));
-const StarsCanvas = lazy(() => import("./components/canvas/Stars"));
-
-const App = () => {
-  const [mountStars, setMountStars] = useState(false);
-
-  useEffect(() => {
-    if (typeof window === "undefined") return undefined;
-
-    const enable = () => setMountStars(true);
-
-    if ("requestIdleCallback" in window) {
-      const idleId = window.requestIdleCallback(enable);
-      return () => {
-        if ("cancelIdleCallback" in window) {
-          window.cancelIdleCallback(idleId);
-        }
-      };
-    }
-
-    const timeoutId = window.setTimeout(enable, 1200);
-    return () => window.clearTimeout(timeoutId);
-  }, []);
-
-  return (
-    <BrowserRouter>
-      <div className='relative z-0 bg-primary'>
-        <div className='bg-hero-pattern bg-cover bg-no-repeat bg-center'>
-          <Suspense fallback={<CanvasLoader />}>
-            <Navbar />
-          </Suspense>
-          <Suspense fallback={<CanvasLoader />}>
-            <Hero />
-          </Suspense>
-        </div>
-        <Suspense fallback={<CanvasLoader />}>
-          <About />
-        </Suspense>
-        <Suspense fallback={<CanvasLoader />}>
-          <Experience />
-        </Suspense>
-        <Suspense fallback={<CanvasLoader />}>
-          <Works />
-        </Suspense>
-        <Suspense fallback={<CanvasLoader />}>
-          <Feedbacks />
-        </Suspense>
-        <Suspense fallback={<CanvasLoader />}>
-          <Tech />
-        </Suspense>
-        <div className='relative z-0'>
-          <Suspense fallback={<CanvasLoader />}>
-            <Contact />
-          </Suspense>
-
-          <Suspense fallback={null}>
-            {mountStars ? <StarsCanvas /> : null}
-          </Suspense>
-        </div>
-      </div>
-    </BrowserRouter>
-  );
-};
+const App = () => (
+  <div className='min-h-screen bg-slate-950 text-slate-100'>
+    <Header />
+    <main>
+      <Hero />
+      <FeatureGrid />
+      <Testimonials />
+      <Pricing />
+      <Faq />
+      <Cta />
+    </main>
+    <Footer />
+  </div>
+);
 
 export default App;

--- a/src/components/microchat/ConversationPreview.jsx
+++ b/src/components/microchat/ConversationPreview.jsx
@@ -1,0 +1,76 @@
+const ConversationPreview = () => (
+  <div
+    id='product'
+    className='relative w-full max-w-lg rounded-[2rem] border border-slate-800/60 bg-slate-900/70 p-6 shadow-2xl shadow-slate-950/60 backdrop-blur'
+  >
+    <div className='flex items-center justify-between pb-4'>
+      <div>
+        <p className='text-xs font-medium uppercase tracking-[0.3em] text-slate-400'>Live inbox</p>
+        <h2 className='text-lg font-semibold text-white'>Growth launch campaign</h2>
+      </div>
+      <div className='flex items-center gap-1 rounded-full border border-slate-800/60 bg-slate-950/60 px-3 py-1 text-[10px] font-semibold uppercase tracking-[0.2em] text-emerald-300'>
+        Online
+        <span className='h-1.5 w-1.5 rounded-full bg-emerald-400' />
+      </div>
+    </div>
+    <div className='space-y-4 rounded-2xl border border-slate-800/60 bg-slate-950/60 p-4'>
+      <div className='flex items-start gap-3'>
+        <div className='flex h-9 w-9 items-center justify-center rounded-xl bg-emerald-500/20 text-sm font-semibold text-emerald-300'>
+          AV
+        </div>
+        <div className='flex-1 rounded-2xl bg-slate-800/70 p-3 text-sm text-slate-100 shadow-inner shadow-slate-950/40'>
+          Hey there! I just landed on your pricing page — do you offer annual discounts for teams of 20?
+        </div>
+      </div>
+      <div className='flex flex-row-reverse items-start gap-3'>
+        <div className='flex h-9 w-9 items-center justify-center rounded-xl bg-sky-500/20 text-sm font-semibold text-sky-300'>
+          You
+        </div>
+        <div className='flex-1 rounded-2xl bg-gradient-to-br from-sky-500/80 via-indigo-400/80 to-blue-500/80 p-3 text-sm text-slate-950 shadow-[0_0_25px_rgba(56,189,248,0.35)]'>
+          Absolutely! The Growth plan includes 15% off for annual commitments and comes with automations + analytics.
+        </div>
+      </div>
+      <div className='flex items-start gap-3'>
+        <div className='flex h-9 w-9 items-center justify-center rounded-xl bg-fuchsia-500/20 text-sm font-semibold text-fuchsia-300'>
+          AI
+        </div>
+        <div className='flex-1 space-y-2 rounded-2xl bg-slate-800/70 p-3 text-sm text-slate-200 shadow-inner shadow-slate-950/40'>
+          <p className='font-semibold text-white'>Draft reply</p>
+          <p>
+            I can also share a quick overview of how automation studio works if you are evaluating onboarding flows. Would that help?
+          </p>
+          <div className='flex flex-wrap gap-2 pt-1'>
+            <button
+              type='button'
+              className='rounded-full border border-slate-700 px-3 py-1 text-xs font-semibold text-slate-200 transition hover:border-slate-500 hover:text-white'
+            >
+              Insert & send
+            </button>
+            <button
+              type='button'
+              className='rounded-full border border-transparent bg-slate-900/80 px-3 py-1 text-xs font-semibold text-slate-300 transition hover:border-slate-700 hover:bg-slate-900'
+            >
+              Regenerate
+            </button>
+          </div>
+        </div>
+      </div>
+    </div>
+    <div className='mt-5 grid grid-cols-3 gap-3 text-center text-xs font-semibold text-slate-300'>
+      <div className='rounded-2xl border border-slate-800/60 bg-slate-950/70 p-3'>
+        <p className='text-[11px] uppercase tracking-[0.25em] text-slate-500'>Handle time</p>
+        <p className='mt-2 text-lg text-white'>1m 12s</p>
+      </div>
+      <div className='rounded-2xl border border-slate-800/60 bg-slate-950/70 p-3'>
+        <p className='text-[11px] uppercase tracking-[0.25em] text-slate-500'>Sentiment</p>
+        <p className='mt-2 text-lg text-emerald-300'>Delighted</p>
+      </div>
+      <div className='rounded-2xl border border-slate-800/60 bg-slate-950/70 p-3'>
+        <p className='text-[11px] uppercase tracking-[0.25em] text-slate-500'>Priority</p>
+        <p className='mt-2 text-lg text-sky-300'>VIP</p>
+      </div>
+    </div>
+  </div>
+);
+
+export default ConversationPreview;

--- a/src/components/microchat/Cta.jsx
+++ b/src/components/microchat/Cta.jsx
@@ -1,0 +1,32 @@
+const Cta = () => (
+  <section className='relative overflow-hidden py-24'>
+    <div className='absolute inset-0 bg-gradient-to-br from-sky-500/20 via-indigo-500/10 to-emerald-500/20 blur-3xl' aria-hidden='true' />
+    <div className='relative mx-auto max-w-4xl rounded-[3rem] border border-slate-800/60 bg-slate-950/90 px-6 py-16 text-center shadow-2xl shadow-slate-950/60 sm:px-12'>
+      <p className='text-sm font-semibold uppercase tracking-[0.3em] text-sky-300'>Ready in minutes</p>
+      <h2 className='mt-4 text-3xl font-semibold tracking-tight text-white sm:text-4xl'>
+        Deploy on Vercel and start chatting today.
+      </h2>
+      <p className='mt-4 text-base leading-relaxed text-slate-300'>
+        Connect your data sources, invite your team, and go live with a single script tag. No credit card required.
+      </p>
+      <div className='mt-8 flex flex-col justify-center gap-3 sm:flex-row'>
+        <a
+          href='https://vercel.com/new'
+          target='_blank'
+          rel='noreferrer'
+          className='inline-flex items-center justify-center rounded-lg bg-gradient-to-r from-sky-400 via-indigo-400 to-blue-500 px-6 py-3 text-sm font-semibold text-slate-950 shadow-lg shadow-sky-500/30 transition hover:brightness-110'
+        >
+          Deploy to Vercel
+        </a>
+        <a
+          href='mailto:hello@microchat.dev'
+          className='inline-flex items-center justify-center rounded-lg border border-slate-800 px-6 py-3 text-sm font-semibold text-slate-200 transition hover:border-slate-700 hover:text-white'
+        >
+          Contact sales
+        </a>
+      </div>
+    </div>
+  </section>
+);
+
+export default Cta;

--- a/src/components/microchat/Faq.jsx
+++ b/src/components/microchat/Faq.jsx
@@ -1,0 +1,35 @@
+import { faqs } from "../../constants/microchat";
+
+const Faq = () => (
+  <section id='faq' className='border-b border-slate-800/60 bg-slate-950/60 py-24'>
+    <div className='mx-auto max-w-5xl px-4 sm:px-6 lg:px-8'>
+      <div className='max-w-3xl space-y-4 text-center sm:mx-auto'>
+        <p className='text-sm font-semibold uppercase tracking-[0.3em] text-sky-300'>FAQ</p>
+        <h2 className='text-3xl font-semibold tracking-tight text-white sm:text-4xl'>
+          Answers to common questions.
+        </h2>
+        <p className='text-base leading-relaxed text-slate-300'>
+          Can’t find what you’re looking for? Drop us a message from the widget and we’ll follow up in minutes.
+        </p>
+      </div>
+      <div className='mt-12 space-y-6'>
+        {faqs.map((faq) => (
+          <details
+            key={faq.question}
+            className='group rounded-3xl border border-slate-800/60 bg-slate-900/60 p-6 shadow-lg shadow-slate-950/40 transition hover:border-slate-700'
+          >
+            <summary className='flex cursor-pointer items-center justify-between text-left text-lg font-semibold text-white'>
+              {faq.question}
+              <span className='ml-4 inline-flex h-8 w-8 items-center justify-center rounded-full border border-slate-700 text-sm text-slate-300 transition group-open:rotate-45'>
+                +
+              </span>
+            </summary>
+            <p className='mt-4 text-sm leading-relaxed text-slate-300'>{faq.answer}</p>
+          </details>
+        ))}
+      </div>
+    </div>
+  </section>
+);
+
+export default Faq;

--- a/src/components/microchat/FeatureGrid.jsx
+++ b/src/components/microchat/FeatureGrid.jsx
@@ -1,0 +1,48 @@
+import { featureCards, metrics } from "../../constants/microchat";
+
+const FeatureGrid = () => (
+  <section
+    id='features'
+    className='border-b border-slate-800/60 bg-slate-950/40 py-24'
+  >
+    <div className='mx-auto flex max-w-6xl flex-col gap-16 px-4 sm:px-6 lg:px-8'>
+      <div className='max-w-3xl space-y-4'>
+        <p className='text-sm font-semibold uppercase tracking-[0.3em] text-sky-300'>Platform</p>
+        <h2 className='text-3xl font-semibold tracking-tight text-white sm:text-4xl'>
+          Designed for flow, built for scale.
+        </h2>
+        <p className='text-base leading-relaxed text-slate-300'>
+          Microchat keeps your team focused on the conversations that matter with opinionated workflows, instant automations, and observability out of the box.
+        </p>
+      </div>
+      <div className='grid gap-6 md:grid-cols-2'>
+        {featureCards.map((feature) => (
+          <div
+            key={feature.title}
+            className='group relative overflow-hidden rounded-3xl border border-slate-800/60 bg-slate-900/60 p-8 shadow-xl shadow-slate-950/50 transition duration-300 hover:border-slate-700 hover:shadow-sky-500/20'
+          >
+            <div className='absolute inset-x-8 top-0 h-1 rounded-b-full bg-gradient-to-r from-sky-400 via-indigo-400 to-blue-500 opacity-0 transition duration-300 group-hover:opacity-100' />
+            <h3 className='text-xl font-semibold text-white'>{feature.title}</h3>
+            <p className='mt-4 text-sm leading-relaxed text-slate-300'>{feature.description}</p>
+            <div className='mt-6 inline-flex items-center gap-2 text-sm font-semibold text-sky-300'>
+              Explore feature
+              <svg className='h-4 w-4' viewBox='0 0 24 24' fill='none' stroke='currentColor' strokeWidth='2'>
+                <path strokeLinecap='round' strokeLinejoin='round' d='M5 12h14M13 5l7 7-7 7' />
+              </svg>
+            </div>
+          </div>
+        ))}
+      </div>
+      <dl className='grid gap-6 rounded-3xl border border-slate-800/60 bg-slate-900/40 p-8 sm:grid-cols-2 lg:grid-cols-4'>
+        {metrics.map((metric) => (
+          <div key={metric.label} className='space-y-2 text-center sm:text-left'>
+            <dt className='text-xs font-semibold uppercase tracking-[0.3em] text-slate-500'>{metric.label}</dt>
+            <dd className='text-3xl font-semibold text-white'>{metric.value}</dd>
+          </div>
+        ))}
+      </dl>
+    </div>
+  </section>
+);
+
+export default FeatureGrid;

--- a/src/components/microchat/Footer.jsx
+++ b/src/components/microchat/Footer.jsx
@@ -1,0 +1,21 @@
+import { navigation } from "../../constants/microchat";
+
+const Footer = () => (
+  <footer className='border-t border-slate-800/60 bg-slate-950/80'>
+    <div className='mx-auto flex max-w-6xl flex-col gap-6 px-4 py-10 text-sm text-slate-400 sm:flex-row sm:items-center sm:justify-between sm:px-6 lg:px-8'>
+      <div className='flex flex-col gap-2 text-center sm:text-left'>
+        <div className='text-base font-semibold text-white'>Microchat</div>
+        <p className='text-xs text-slate-500'>Built on Vercel’s edge network for teams that move fast.</p>
+      </div>
+      <nav className='flex flex-wrap justify-center gap-4 text-xs font-semibold uppercase tracking-[0.3em] sm:justify-end'>
+        {navigation.map((item) => (
+          <a key={item.label} href={item.href} className='transition hover:text-white'>
+            {item.label}
+          </a>
+        ))}
+      </nav>
+    </div>
+  </footer>
+);
+
+export default Footer;

--- a/src/components/microchat/Header.jsx
+++ b/src/components/microchat/Header.jsx
@@ -1,0 +1,95 @@
+import { useState } from "react";
+import { navigation } from "../../constants/microchat";
+
+const Header = () => {
+  const [mobileOpen, setMobileOpen] = useState(false);
+
+  return (
+    <header className='sticky top-0 z-50 border-b border-slate-800/60 bg-slate-950/80 backdrop-blur'>
+      <div className='mx-auto flex max-w-6xl items-center justify-between px-4 py-4 sm:px-6 lg:px-8'>
+        <a href='#top' className='flex items-center gap-2 text-lg font-semibold tracking-tight text-white'>
+          <span className='inline-flex h-9 w-9 items-center justify-center rounded-xl bg-gradient-to-br from-sky-400 via-emerald-400 to-blue-500 text-base font-bold text-slate-950 shadow-lg shadow-sky-500/40'>
+            µ
+          </span>
+          Microchat
+        </a>
+        <nav className='hidden items-center gap-8 text-sm font-medium text-slate-200 md:flex'>
+          {navigation.map((item) => (
+            <a
+              key={item.label}
+              href={item.href}
+              className='transition hover:text-white hover:underline hover:underline-offset-4'
+            >
+              {item.label}
+            </a>
+          ))}
+        </nav>
+        <div className='hidden items-center gap-3 md:flex'>
+          <a
+            href='#pricing'
+            className='rounded-lg border border-slate-800 px-4 py-2 text-sm font-semibold text-slate-200 transition hover:border-slate-700 hover:text-white'
+          >
+            Pricing
+          </a>
+          <a
+            href='https://vercel.com/import/git'
+            target='_blank'
+            rel='noreferrer'
+            className='rounded-lg bg-gradient-to-r from-sky-400 via-indigo-400 to-blue-500 px-4 py-2 text-sm font-semibold text-slate-950 shadow-lg shadow-sky-500/30 transition hover:brightness-110'
+          >
+            Launch app
+          </a>
+        </div>
+        <button
+          type='button'
+          onClick={() => setMobileOpen((prev) => !prev)}
+          className='inline-flex items-center justify-center rounded-lg border border-slate-800 p-2 text-slate-200 transition hover:border-slate-700 hover:text-white md:hidden'
+          aria-expanded={mobileOpen}
+          aria-label='Toggle navigation'
+        >
+          <svg className='h-5 w-5' viewBox='0 0 24 24' fill='none' stroke='currentColor' strokeWidth='2'>
+            {mobileOpen ? (
+              <path strokeLinecap='round' strokeLinejoin='round' d='M6 18L18 6M6 6l12 12' />
+            ) : (
+              <path strokeLinecap='round' strokeLinejoin='round' d='M4 6h16M4 12h16M4 18h16' />
+            )}
+          </svg>
+        </button>
+      </div>
+      {mobileOpen ? (
+        <div className='border-t border-slate-800/60 bg-slate-950/95 md:hidden'>
+          <nav className='mx-auto flex max-w-6xl flex-col gap-3 px-4 py-4 text-sm font-medium text-slate-200 sm:px-6'>
+            {navigation.map((item) => (
+              <a
+                key={item.label}
+                href={item.href}
+                className='rounded-lg px-3 py-2 transition hover:bg-slate-900/80 hover:text-white'
+                onClick={() => setMobileOpen(false)}
+              >
+                {item.label}
+              </a>
+            ))}
+            <a
+              href='#pricing'
+              className='rounded-lg px-3 py-2 transition hover:bg-slate-900/80 hover:text-white'
+              onClick={() => setMobileOpen(false)}
+            >
+              Pricing
+            </a>
+            <a
+              href='https://vercel.com/import/git'
+              target='_blank'
+              rel='noreferrer'
+              className='rounded-lg bg-gradient-to-r from-sky-400 via-indigo-400 to-blue-500 px-3 py-2 text-center text-sm font-semibold text-slate-950 shadow-lg shadow-sky-500/30 transition hover:brightness-110'
+              onClick={() => setMobileOpen(false)}
+            >
+              Launch app
+            </a>
+          </nav>
+        </div>
+      ) : null}
+    </header>
+  );
+};
+
+export default Header;

--- a/src/components/microchat/Hero.jsx
+++ b/src/components/microchat/Hero.jsx
@@ -1,0 +1,52 @@
+import ConversationPreview from "./ConversationPreview";
+import { highlights } from "../../constants/microchat";
+
+const Hero = () => (
+  <section id='top' className='relative overflow-hidden border-b border-slate-800/60 bg-gradient-to-br from-slate-950 via-slate-900 to-slate-950'>
+    <div className='absolute -right-40 -top-40 h-72 w-72 rounded-full bg-sky-500/30 blur-3xl sm:h-96 sm:w-96' aria-hidden='true' />
+    <div className='absolute bottom-[-10rem] left-[-8rem] h-80 w-80 rounded-full bg-emerald-400/20 blur-3xl sm:h-96 sm:w-96' aria-hidden='true' />
+    <div className='mx-auto flex max-w-6xl flex-col gap-12 px-4 py-24 sm:px-6 lg:flex-row lg:items-center lg:gap-16 lg:px-8'>
+      <div className='max-w-xl space-y-6'>
+        <span className='inline-flex items-center gap-2 rounded-full border border-slate-800/80 bg-slate-900/80 px-4 py-2 text-xs font-medium uppercase tracking-[0.2em] text-sky-300 shadow-lg shadow-sky-500/10'>
+          Lightning fast support
+        </span>
+        <h1 className='text-4xl font-semibold leading-tight tracking-tight text-white sm:text-5xl lg:text-6xl'>
+          Customer conversations that feel human, not hectic.
+        </h1>
+        <p className='text-base leading-relaxed text-slate-300 sm:text-lg'>
+          Microchat centralizes every message and powers your team with intelligent automations so you can deliver personal, 24/7 support without adding headcount.
+        </p>
+        <div className='flex flex-col gap-3 sm:flex-row sm:items-center'>
+          <a
+            href='#pricing'
+            className='inline-flex items-center justify-center rounded-lg bg-gradient-to-r from-sky-400 via-indigo-400 to-blue-500 px-6 py-3 text-sm font-semibold text-slate-950 shadow-lg shadow-sky-500/30 transition hover:brightness-110'
+          >
+            Start for free
+          </a>
+          <a
+            href='#product'
+            className='inline-flex items-center justify-center rounded-lg border border-slate-800 px-6 py-3 text-sm font-semibold text-slate-200 transition hover:border-slate-700 hover:text-white'
+          >
+            See product tour
+          </a>
+        </div>
+        <div className='grid gap-5 pt-6 sm:grid-cols-3 sm:gap-6'>
+          {highlights.map((item) => (
+            <div
+              key={item.title}
+              className='rounded-2xl border border-slate-800/60 bg-slate-900/70 p-4 shadow-inner shadow-slate-950/40 transition hover:border-slate-700'
+            >
+              <h3 className='text-sm font-semibold text-white'>{item.title}</h3>
+              <p className='mt-2 text-xs leading-relaxed text-slate-400'>{item.description}</p>
+            </div>
+          ))}
+        </div>
+      </div>
+      <div className='relative flex flex-1 justify-center lg:justify-end'>
+        <ConversationPreview />
+      </div>
+    </div>
+  </section>
+);
+
+export default Hero;

--- a/src/components/microchat/Pricing.jsx
+++ b/src/components/microchat/Pricing.jsx
@@ -1,0 +1,63 @@
+import { plans } from "../../constants/microchat";
+
+const Pricing = () => (
+  <section id='pricing' className='border-b border-slate-800/60 bg-slate-950/40 py-24'>
+    <div className='mx-auto max-w-6xl px-4 sm:px-6 lg:px-8'>
+      <div className='max-w-3xl space-y-4'>
+        <p className='text-sm font-semibold uppercase tracking-[0.3em] text-sky-300'>Pricing</p>
+        <h2 className='text-3xl font-semibold tracking-tight text-white sm:text-4xl'>
+          Choose a plan that grows with you.
+        </h2>
+        <p className='text-base leading-relaxed text-slate-300'>
+          Every plan comes with realtime messaging, the unified inbox, and access to our library of automation templates.
+        </p>
+      </div>
+      <div className='mt-12 grid gap-8 md:grid-cols-3'>
+        {plans.map((plan) => (
+          <div
+            key={plan.name}
+            className={`relative flex h-full flex-col rounded-3xl border border-slate-800/60 bg-slate-900/60 p-8 shadow-xl shadow-slate-950/50 ${
+              plan.highlighted ? "ring-2 ring-sky-400" : ""
+            }`}
+          >
+            {plan.highlighted ? (
+              <span className='absolute -top-4 left-1/2 -translate-x-1/2 rounded-full bg-gradient-to-r from-sky-400 via-indigo-400 to-blue-500 px-4 py-1 text-xs font-semibold uppercase tracking-[0.3em] text-slate-950 shadow-lg shadow-sky-500/30'>
+                Most popular
+              </span>
+            ) : null}
+            <h3 className='text-2xl font-semibold text-white'>{plan.name}</h3>
+            <p className='mt-3 text-sm leading-relaxed text-slate-300'>{plan.description}</p>
+            <div className='mt-6 flex items-baseline gap-2'>
+              <span className='text-4xl font-semibold text-white'>{plan.price}</span>
+              <span className='text-xs font-semibold uppercase tracking-[0.3em] text-slate-500'>{plan.frequency}</span>
+            </div>
+            <ul className='mt-6 space-y-3 text-sm text-slate-200'>
+              {plan.highlights.map((highlight) => (
+                <li key={highlight} className='flex items-start gap-3'>
+                  <span className='mt-1 inline-flex h-2.5 w-2.5 flex-none rounded-full bg-sky-400 shadow-[0_0_10px_rgba(56,189,248,0.6)]' />
+                  <span>{highlight}</span>
+                </li>
+              ))}
+            </ul>
+            <div className='mt-10'>
+              <a
+                href='https://vercel.com/import/git'
+                target='_blank'
+                rel='noreferrer'
+                className={`inline-flex w-full items-center justify-center rounded-lg px-5 py-3 text-sm font-semibold transition ${
+                  plan.highlighted
+                    ? "bg-gradient-to-r from-sky-400 via-indigo-400 to-blue-500 text-slate-950 shadow-lg shadow-sky-500/30 hover:brightness-110"
+                    : "border border-slate-800 text-slate-200 hover:border-slate-700 hover:text-white"
+                }`}
+              >
+                {plan.highlighted ? "Start trial" : "Talk to sales"}
+              </a>
+            </div>
+          </div>
+        ))}
+      </div>
+    </div>
+  </section>
+);
+
+export default Pricing;

--- a/src/components/microchat/Testimonials.jsx
+++ b/src/components/microchat/Testimonials.jsx
@@ -1,0 +1,38 @@
+import { testimonials } from "../../constants/microchat";
+
+const Testimonials = () => (
+  <section
+    id='testimonials'
+    className='border-b border-slate-800/60 bg-gradient-to-br from-slate-950 via-slate-900 to-slate-950 py-24'
+  >
+    <div className='mx-auto max-w-6xl px-4 sm:px-6 lg:px-8'>
+      <div className='max-w-3xl space-y-4'>
+        <p className='text-sm font-semibold uppercase tracking-[0.3em] text-sky-300'>Loved by teams</p>
+        <h2 className='text-3xl font-semibold tracking-tight text-white sm:text-4xl'>
+          Modern support orgs run on Microchat.
+        </h2>
+        <p className='text-base leading-relaxed text-slate-300'>
+          From scrappy startups to global enterprises, Microchat unlocks faster replies and more delighted customers.
+        </p>
+      </div>
+      <div className='mt-12 grid gap-8 md:grid-cols-3'>
+        {testimonials.map((testimonial) => (
+          <figure
+            key={testimonial.author}
+            className='flex h-full flex-col justify-between rounded-3xl border border-slate-800/60 bg-slate-900/60 p-8 shadow-xl shadow-slate-950/50'
+          >
+            <blockquote className='text-sm leading-relaxed text-slate-200'>
+              “{testimonial.quote}”
+            </blockquote>
+            <figcaption className='mt-6 text-sm font-semibold text-white'>
+              <div>{testimonial.author}</div>
+              <div className='mt-1 text-xs font-medium uppercase tracking-[0.2em] text-slate-500'>{testimonial.role}</div>
+            </figcaption>
+          </figure>
+        ))}
+      </div>
+    </div>
+  </section>
+);
+
+export default Testimonials;

--- a/src/constants/microchat.js
+++ b/src/constants/microchat.js
@@ -1,0 +1,139 @@
+export const navigation = [
+  { label: "Product", href: "#product" },
+  { label: "Features", href: "#features" },
+  { label: "Pricing", href: "#pricing" },
+  { label: "Testimonials", href: "#testimonials" },
+  { label: "FAQ", href: "#faq" },
+];
+
+export const highlights = [
+  {
+    title: "Realtime by default",
+    description:
+      "Watch conversations update instantly with millisecond level sync across web, desktop, and mobile clients.",
+  },
+  {
+    title: "AI assistance",
+    description:
+      "Let Microchat help triage repetitive questions and draft empathetic responses with GPT powered copilots.",
+  },
+  {
+    title: "Team ready",
+    description:
+      "Assign conversations, mention teammates, and review message history with a unified shared inbox.",
+  },
+];
+
+export const featureCards = [
+  {
+    title: "Unified inbox",
+    description:
+      "Combine email, chat, and social DMs into a single timeline with contextual customer profiles and automations.",
+  },
+  {
+    title: "Automation studio",
+    description:
+      "Drag and drop workflows that greet new visitors, route VIPs, and escalate issues with zero code required.",
+  },
+  {
+    title: "Analytics built-in",
+    description:
+      "Track handle time, CSAT, and agent performance with shareable dashboards refreshed in real time.",
+  },
+  {
+    title: "Global infrastructure",
+    description:
+      "Edge delivered architecture keeps latency under 50ms worldwide with redundant failover for peace of mind.",
+  },
+];
+
+export const metrics = [
+  { label: "Avg. response time", value: "42s" },
+  { label: "Customer satisfaction", value: "98%" },
+  { label: "Messages handled", value: "12M+" },
+  { label: "Integrations", value: "45" },
+];
+
+export const testimonials = [
+  {
+    quote:
+      "Microchat helped us replace three different tools and ship same-day replies. Our customers noticed immediately.",
+    author: "Cleo Manning",
+    role: "Head of Support, Apex Labs",
+  },
+  {
+    quote:
+      "We launched proactive onboarding sequences without engineering time. Activation jumped 27% in one week.",
+    author: "Jordan Vega",
+    role: "Growth Lead, NovaDesk",
+  },
+  {
+    quote:
+      "The AI summarization keeps leadership in the loop. Standups finally focus on strategy instead of status updates.",
+    author: "Priya Shah",
+    role: "COO, Brightside",
+  },
+];
+
+export const plans = [
+  {
+    name: "Starter",
+    price: "$0",
+    frequency: "forever",
+    description: "Perfect for early teams getting their first live chat channel online.",
+    highlights: [
+      "Up to 3 teammates",
+      "Shared inbox",
+      "Customizable chat widget",
+      "AI suggested replies",
+    ],
+  },
+  {
+    name: "Growth",
+    price: "$39",
+    frequency: "per agent / month",
+    description: "Scale with automations, analytics, and native integrations.",
+    highlighted: true,
+    highlights: [
+      "Unlimited teammates",
+      "Workflow automations",
+      "Advanced analytics",
+      "Priority email support",
+    ],
+  },
+  {
+    name: "Enterprise",
+    price: "Let's talk",
+    frequency: "custom",
+    description: "Dedicated success, compliance reviews, and bespoke SLAs.",
+    highlights: [
+      "Dedicated success manager",
+      "Audit logs",
+      "SAML SSO",
+      "On-premise options",
+    ],
+  },
+];
+
+export const faqs = [
+  {
+    question: "Can I migrate from my existing chat tool?",
+    answer:
+      "Absolutely. Our success engineers import historical conversations, users, tags, and automations so you can switch in a weekend.",
+  },
+  {
+    question: "Is there a free plan?",
+    answer:
+      "Yes. The Starter plan stays free forever with generous limits. Upgrade whenever you need automation or advanced analytics.",
+  },
+  {
+    question: "Do you support mobile SDKs?",
+    answer:
+      "We provide native iOS and Android SDKs plus a lightweight web component for embedding the chat widget anywhere.",
+  },
+  {
+    question: "Where are you hosted?",
+    answer:
+      "Microchat is deployed on Vercel's global edge network with regional data residency options in the EU, US, and APAC.",
+  },
+];


### PR DESCRIPTION
## Summary
- replace the existing portfolio experience with a Microchat-themed marketing layout and responsive header/footer
- add a conversation preview hero and data-driven sections for features, testimonials, pricing, and FAQs
- centralize marketing copy in a new constants module for reuse across the landing page

## Testing
- npm run build

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_6912d01235048330b1aa443928a1a152)